### PR TITLE
added DEBUG variable controlling debug behavior

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ "$DEBUG" == "TRUE" ]
+then  
+while true; do sleep 10000; done
+else
 # write the configuration file
 python write_config_file.py \
     --cloud-provider=$CLOUD_PROVIDER \
@@ -13,4 +17,4 @@ tensorflow_model_server \
     --model_config_file=$TF_SERVING_CONFIG_FILE \
   && \
 /bin/bash # hack to keep from exiting
-# while true; do sleep 1000; done
+fi


### PR DESCRIPTION
This commit, in conjunction with the commit in the `tf-serving-chart-tweak` branch of the `kiosk` project, gives the tf-serving container the option of either 1) executing its standard startup script or 2) entering a very long sleep loop, allowing the Kubernetes admin to exec into the container and start tf-serving manually, so that the person can see all of the debug info from tf-serving.

It might not be a bad idea to add this DEBUG functionality to all startup scripts used by kiosk containers.