### PR TITLE
change shebang line to "bash" instead of "sh" to use "[" operator

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,9 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$DEBUG" == "TRUE" ]
 then  
 while true; do sleep 10000; done
 else
+
 # write the configuration file
 python write_config_file.py \
     --cloud-provider=$CLOUD_PROVIDER \
@@ -17,4 +18,5 @@ tensorflow_model_server \
     --model_config_file=$TF_SERVING_CONFIG_FILE \
   && \
 /bin/bash # hack to keep from exiting
+
 fi


### PR DESCRIPTION
Fixes #10 
the shebang line was `#!/bin/sh` which told docker to run `/bin/sh .../entrypoint.sh`.  Apparently `sh` does not support the `[` or `]` bash operators for evaluation.  switching the shebang line to `#!/bin/bash` tells Docker to use `bash` instead, and this error goes away.