### PR TITLE
TensorFlow-Serving v1.12.0 enables prometheus monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # ============================================================================
 
 # Using official tensorflow-serving as base image
-ARG TF_SERVING_VERSION=1.13.0
+ARG TF_SERVING_VERSION=1.11.1
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
 
 FROM ${TF_SERVING_BUILD_IMAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # ============================================================================
 
 # Using official tensorflow-serving as base image
-ARG TF_SERVING_VERSION=1.11.1
+ARG TF_SERVING_VERSION=1.13.0
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
 
 FROM ${TF_SERVING_BUILD_IMAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # ============================================================================
 
 # Using official tensorflow-serving as base image
-ARG TF_SERVING_VERSION=1.10.1
+ARG TF_SERVING_VERSION=1.11.1
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
 
 FROM ${TF_SERVING_BUILD_IMAGE}
@@ -33,7 +33,7 @@ FROM ${TF_SERVING_BUILD_IMAGE}
 WORKDIR /kiosk/tf-serving
 
 ENV PORT=8500 \
-    REST_API_PORT=0 \
+    REST_API_PORT=8501 \
     REST_API_TIMEOUT=30000 \
     ENABLE_BATCHING=false \
     TF_CPP_MIN_LOG_LEVEL=0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # ============================================================================
 
 # Using official tensorflow-serving as base image
-ARG TF_SERVING_VERSION=1.13.0
+ARG TF_SERVING_VERSION=1.12.0
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
 
 FROM ${TF_SERVING_BUILD_IMAGE}

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -15,5 +15,3 @@ tensorflow_model_server \
     --grpc_channel_arguments=$GRPC_CHANNEL_ARGS \
   && \
 /bin/bash # hack to keep from exiting
-
-fi

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -13,5 +13,6 @@ tensorflow_model_server \
     --model_config_file=$MODEL_CONFIG_FILE \
     --enable_batching=$ENABLE_BATCHING \
     --grpc_channel_arguments=$GRPC_CHANNEL_ARGS \
+    --monitoring_config_file=./monitoring_config.txt \
   && \
 /bin/bash # hack to keep from exiting

--- a/monitoring_config.txt
+++ b/monitoring_config.txt
@@ -1,0 +1,4 @@
+prometheus_config: {
+  enable: true,
+  path: "/monitoring/prometheus/metrics"
+}


### PR DESCRIPTION
By default, the `1.13.0` version of TensorFlow Serving (using `1.13.1` of TensorFlow) enables a REST API endpoint `/monitoring/prometheus/metrics` for prometheus monitoring.  This PR updates the version to enable this, and changes the default `REST_API_PORT` to be 8501.