### PR TITLE
set `AWS_LOG_LEVEL` to 3 to stop AWS log-spamming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV PORT=8500 \
     REST_API_TIMEOUT=30000 \
     ENABLE_BATCHING=false \
     TF_CPP_MIN_LOG_LEVEL=0 \
+    AWS_LOG_LEVEL=3 \
     GRPC_CHANNEL_ARGS="" \
     MODEL_CONFIG_FILE=/kiosk/tf-serving/models.conf
 


### PR DESCRIPTION
fixes #8 