### PR TITLE
Update base image to 1.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # ============================================================================
 
 # Using official tensorflow-serving as base image
-ARG TF_SERVING_VERSION=1.14.0
+ARG TF_SERVING_VERSION=1.15.0
 ARG TF_SERVING_BUILD_IMAGE=tensorflow/serving:${TF_SERVING_VERSION}-devel-gpu
 
 FROM ${TF_SERVING_BUILD_IMAGE}


### PR DESCRIPTION
`1.15.0` is the final `1.x` release for `tensorflow-serving`.  This version supports all of the default models for deepcell.org.